### PR TITLE
イベント通知時にエラーが起きても続行する

### DIFF
--- a/src/lepus/signals.py
+++ b/src/lepus/signals.py
@@ -1,16 +1,22 @@
 # encoding=utf-8
 import requests
 import json
+import logging
 from django.core.signals import request_finished
 from django.dispatch import Signal, receiver
 from django.db.models.signals import post_save
 from django.conf import settings
 from lepus.models import Answer, Notice, Category, Question, File
 
+logger = logging.getLogger(__name__)
+
 def send_realtime_event(data):
     if settings.PUSH_EVENT_URL:
         headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
-        response = requests.post(settings.PUSH_EVENT_URL, data=json.dumps(data), headers=headers)
+        try:
+            response = requests.post(settings.PUSH_EVENT_URL, data=json.dumps(data), headers=headers)
+        except:
+            logger.error("Cannot send push event %s.", data.get("type"))
 
 @receiver(post_save, sender=Answer)
 def on_answer_sent(sender, **kwargs):


### PR DESCRIPTION
イベント通知機能へのイベント通知が失敗した場合、リクエストの処理自体が失敗する。

イベント通知機能自体はCTFにおいてクリティカルではないので、エラーとせずにリクエストの処理は続行されるようにした。
